### PR TITLE
add time_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ $ sudo /usr/lib64/fluent/ruby/bin/fluent-gem install fluent-plugin-amplitude
   api_key XXXXXX
   user_id_key user_id
   device_id_key uuid
+  time_key created_at
   user_properties first_name, last_name
   event_properties current_source
   properties_blacklist user
@@ -43,6 +44,9 @@ AmplitudeOutput needs your Amplitude `api_key` ([see Amplitude for more informat
 
 #### user_id_key and device_id_key
 You must set at least one of `user_id_key` and `device_id_key`. They will be used to pull out the `user_id` and `device_id` values from the record to send to the Amplitude API. Note these can both be arrays, and the first matching key will be used.
+
+#### time_key
+If set, `time_key` will be used to pull out a timestamp field to set as `time` in the Amplitude API request. This can be an array, the first matching key will be used.
 
 #### user_properties and event_properties
 You can optionally specify lists of `user_properties` and `event_properties` to pull from the record.

--- a/spec/out_amplitude_spec.rb
+++ b/spec/out_amplitude_spec.rb
@@ -290,5 +290,50 @@ describe Fluent::AmplitudeOutput do
         amplitude.run
       end
     end
+    context 'time_key specified' do
+      let(:conf) do
+        %(
+          api_key XXXXXX
+          user_id_key user_id
+          device_id_key uuid
+          time_key created_at
+          user_properties first_name, last_name
+          event_properties current_source
+        )
+      end
+      let(:event) do
+        {
+          'user_id' => 42,
+          'uuid' => 'e6153b00-85d8-11e6-b1bc-43192d1e493f',
+          'first_name' => 'Bobby',
+          'last_name' => 'Weir',
+          'state' => 'CA',
+          'current_source' => 'fb_share',
+          'recruiter_id' => 710,
+          'created_at' => '2016-12-20T00:00:06Z'
+        }
+      end
+
+      let(:formatted_event) do
+        {
+          event_type: tag,
+          user_id: 42,
+          device_id: 'e6153b00-85d8-11e6-b1bc-43192d1e493f',
+          time: Time.parse('2016-12-20T00:00:06Z').to_i,
+          user_properties: {
+            first_name: 'Bobby',
+            last_name: 'Weir'
+          },
+          event_properties: {
+            current_source: 'fb_share'
+          }
+        }
+      end
+
+      it 'produces the expected output' do
+        amplitude.expect_format [tag, now, formatted_event].to_msgpack
+        amplitude.run
+      end
+    end
   end
 end


### PR DESCRIPTION
we've been experiencing some issues where events hit amplitude out of creation order, making for some oddities. 

this adds a `time_key` optional config param, that will allow us to pull a `created_at` or whatever off of the event payload and set it as the `time` for the amplitude call.

still TODO might be adding a way to default to the fluentd timestamp. but I'm not sure that's much different than just defaulting to the timestamp of when the event hits amplitude? unless these batches all hit amplitude in reverse order... 

CC @robdiciuccio as he's aware of this issue. 