### PR TITLE
Add support for sending revenue properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,20 @@ You must set at least one of `user_id_key` and `device_id_key`. They will be use
 #### time_key
 If set, `time_key` will be used to pull out a timestamp field to set as `time` in the Amplitude API request. This can be an array, the first matching key will be used.
 
+####  revenue_properties
+
+`revenue_properties` are a fixed set of properties that Amplitude looks for in order to determine which events are revenue events (see Amplitude's [revenue tracking guide](https://amplitude.zendesk.com/hc/en-us/articles/115003116888-Tracking-Revenue) and [HTTP API documentation](https://amplitude.zendesk.com/hc/en-us/articles/204771828#keys-for-the-event-argument) for more information). `revenue_properties` are set as top-level properties on the API call. The `revenue_properties` we currently support are:
+* quantity
+* price
+* revenue
+* revenue_type
+
 #### user_properties and event_properties
 You can optionally specify lists of `user_properties` and `event_properties` to pull from the record.
 
 If `user_properties` are specified, only those properties will be included as `user_properties` in the Amplitude API call.  Otherwise no `user_properties` will be sent.
 
-If `event_properties` are specified, only those properties will be included as `event_properties` in the Amplitude API call. Otherwise the entire record (minus the key/value for `user_id_key` and `device_id_key`, and minus any `user_properties`) will be sent as `event_properties` to Amplitude.
+If `event_properties` are specified, only those properties will be included as `event_properties` in the Amplitude API call. If no `event_properties` are specified, then every field with the exception of `user_id_key`, `device_id_key`, all `revenue_properties`, and anything specified in `user_properties`, will be sent as `event_properties` in the Amplitude API call.
 
 #### event type
 The event_type is the tag.  To modify this, fluent-plugin-amplitude includes the `HandleTagNameMixin` mixin which allows the following options:

--- a/fluent-plugin-amplitude.gemspec
+++ b/fluent-plugin-amplitude.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'fluent-plugin-amplitude'
-  spec.version       = '0.1.1'
+  spec.version       = '0.2.0'
   spec.authors       = ['Change.org']
   spec.email         = ['tech_ops@change.org']
   spec.summary       = 'Fluentd plugin to output event data to Amplitude'

--- a/spec/out_amplitude_spec.rb
+++ b/spec/out_amplitude_spec.rb
@@ -42,7 +42,11 @@ describe Fluent::AmplitudeOutput do
           'last_name' => 'Weir',
           'state' => 'CA',
           'current_source' => 'fb_share',
-          'recruiter_id' => 710
+          'recruiter_id' => 710,
+          'revenue_type' => 'sustainer',
+          'quantity' => 2,
+          'price' => 10.05,
+          'revenue' => 20.10,
         }
       end
 
@@ -51,6 +55,10 @@ describe Fluent::AmplitudeOutput do
           event_type: tag,
           user_id: 42,
           device_id: 'e6153b00-85d8-11e6-b1bc-43192d1e493f',
+          price: 10.05,
+          quantity: 2,
+          revenue: 20.10,
+          revenue_type: 'sustainer',
           user_properties: {
             first_name: 'Bobby',
             last_name: 'Weir'


### PR DESCRIPTION
https://change.atlassian.net/browse/CHANGE-34715

Revenue properties don't get detected by Amplitude if they're inside the `event_properties` hash—they must go into the top level of the event. `amplitude-api` supports revenue properties (https://github.com/toothrot/amplitude-api/blob/master/lib/amplitude_api/event.rb#L129). This adds support on our side.