### PR TITLE
Add additional logging to Amplitude plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
+.ruby-version
 
 *.pem

--- a/fluent-plugin-amplitude.gemspec
+++ b/fluent-plugin-amplitude.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.5'
   spec.add_development_dependency 'test-unit', '~> 3.2', '>= 3.2.1'
   spec.add_development_dependency 'rspec-mocks', '~> 3.5'
-  spec.add_development_dependency 'rubocop', '~> 0.44.1'
+  spec.add_development_dependency 'rubocop', '~> 0.52.0'
 end

--- a/fluent-plugin-amplitude.gemspec
+++ b/fluent-plugin-amplitude.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'fluentd', '>= 0.10.55'
   spec.add_runtime_dependency 'amplitude-api', '~> 0.0.9'
   spec.add_runtime_dependency 'msgpack', '~> 1.0'
+  spec.add_runtime_dependency 'statsd-ruby', '~> 1.0'
 
   spec.add_development_dependency 'rake', '~> 11.3'
   spec.add_development_dependency 'rspec', '~> 3.5'

--- a/lib/fluent/plugin/out_amplitude.rb
+++ b/lib/fluent/plugin/out_amplitude.rb
@@ -163,15 +163,22 @@ module Fluent
     def send_to_amplitude(records)
       log.info("sending #{records.length} to amplitude")
       errors = []
+      records_sent = 0
       until records.empty?
         records_to_send = records.pop(500)
         start_time = Time.now.to_i
         res = AmplitudeAPI.track(records_to_send)
-        unless res.response_code == 200
+        log.info(
+          "Amplitude request complete. Duration: #{res.total_time * 1000}"
+        )
+        if res.response_code == 200
+          records_sent += records_to_send.length
+        else
           fail_time = Time.now.to_i
           errors << [res.response_code, res.body, records_to_send, fail_time - start_time]
         end
       end
+      log.info("sent #{records_sent} to amplitude")
       log_errors(errors)
     end
 

--- a/spec/out_amplitude_spec.rb
+++ b/spec/out_amplitude_spec.rb
@@ -22,9 +22,12 @@ describe Fluent::AmplitudeOutput do
   before do
     Fluent::Test.setup
     expect(AmplitudeAPI).to receive(:api_key=).with('XXXXXX')
+    response = double(:response, response_code: 200)
     allow(AmplitudeAPI).to receive(:track).with(kind_of(Array)).and_return(
-      double(:response, response_code: 200)
+      response
     )
+    allow(response).to receive(:total_time).and_return(123)
+    allow_any_instance_of(Statsd).to receive(:track)
   end
 
   describe '#format' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ Bundler.require(:default, :test)
 
 require 'fluent/test'
 require 'rspec'
+require 'statsd'
 
 Test::Unit::AutoRunner.need_auto_run = false if defined?(Test::Unit::AutoRunner)
 


### PR DESCRIPTION
@change/data-science @change/devops [JIRA](https://change.atlassian.net/browse/CHANGE-37285)

What? Add logging and statsd metric emission to the Amplitude plugin
Why? So we can have a clearer understanding of what the plugin is doing at any given time.

Looking for comments on the general idea - if things look good, I'll add a few more specs before merge & version bump.