### PR TITLE
lower amp event size to 100

### DIFF
--- a/lib/fluent/plugin/out_amplitude.rb
+++ b/lib/fluent/plugin/out_amplitude.rb
@@ -168,7 +168,8 @@ module Fluent
       errors = []
       records_sent = 0
       until records.empty?
-        records_to_send = records.pop(500)
+        # todo make batch size configurable
+        records_to_send = records.pop(100)
         res = AmplitudeAPI.track(records_to_send)
         @statsd.track('fluentd.amplitude.request_time', res.total_time * 1000)
         if res.response_code == 200


### PR DESCRIPTION
We increased the node count by quite a bit, and now there's a rate limit for the number of events by user.  Attempt to quell the errors by lowering the batch size.

@change/data-science @willbarrett 