### PR TITLE
Don't break down chunks into multiple Amplitude API calls

### DIFF
--- a/fluent-plugin-amplitude.gemspec
+++ b/fluent-plugin-amplitude.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'fluent-plugin-amplitude'
-  spec.version       = '0.2.4'
+  spec.version       = '1.0.0'
   spec.authors       = ['Change.org']
   spec.email         = ['tech_ops@change.org']
   spec.summary       = 'Fluentd plugin to output event data to Amplitude'

--- a/fluent-plugin-amplitude.gemspec
+++ b/fluent-plugin-amplitude.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'fluent-plugin-amplitude'
-  spec.version       = '0.2.3'
+  spec.version       = '0.2.4'
   spec.authors       = ['Change.org']
   spec.email         = ['tech_ops@change.org']
   spec.summary       = 'Fluentd plugin to output event data to Amplitude'

--- a/lib/fluent/plugin/out_amplitude.rb
+++ b/lib/fluent/plugin/out_amplitude.rb
@@ -177,23 +177,24 @@ module Fluent
         )
         log.info("sent #{records.length} to amplitude")
       else
-        log_error(
+        error_string = log_error(
           code: res.response_code,
           body: res.body,
           records: records,
           duration: res.total_time * 1000
         )
+        raise AmplitudeError, "Error: #{error_string}"
       end
     end
 
     def log_error(error)
       @statsd.track(
         'fluentd.amplitude.records_errored',
-        records.length
+        error[:records].length
       )
-      error_string = "Response: #{error.code}, Time: #{error.time}, Body: #{error.body}, Duration: #{error.duration}"
+      error_string = "Response: #{error[:code]}, Body: #{error[:body]}, Duration: #{error[:duration]}"
       log.error(error_string)
-      raise AmplitudeError, "Error: #{errors_string}"
+      error_string
     end
   end
 end

--- a/spec/out_amplitude_spec.rb
+++ b/spec/out_amplitude_spec.rb
@@ -1,36 +1,36 @@
 require 'spec_helper'
 require 'amplitude-api'
 describe Fluent::AmplitudeOutput do
-  let(:amplitude_api) { double(:amplitude_api) }
-  let(:now) { Time.now.to_i }
-  let(:tag) { 'after_sign' }
-  let(:amplitude) do
-    Fluent::Test::BufferedOutputTestDriver.new(
-      Fluent::AmplitudeOutput.new
-    ).configure(conf)
-  end
-  let(:conf) do
-    %(
-      api_key XXXXXX
-      user_id_key user_id
-      device_id_key uuid
-      user_properties first_name, last_name
-      event_properties current_source
-    )
-  end
-
-  before do
-    Fluent::Test.setup
-    expect(AmplitudeAPI).to receive(:api_key=).with('XXXXXX')
-    response = double(:response, response_code: 200)
-    allow(AmplitudeAPI).to receive(:track).with(kind_of(Array)).and_return(
-      response
-    )
-    allow(response).to receive(:total_time).and_return(123)
-    allow_any_instance_of(Statsd).to receive(:track)
-  end
-
   describe '#format' do
+    let(:amplitude_api) { double(:amplitude_api) }
+    let(:now) { Time.now.to_i }
+    let(:tag) { 'after_sign' }
+    let(:amplitude) do
+      Fluent::Test::BufferedOutputTestDriver.new(
+        Fluent::AmplitudeOutput.new
+      ).configure(conf)
+    end
+    let(:conf) do
+      %(
+        api_key XXXXXX
+        user_id_key user_id
+        device_id_key uuid
+        user_properties first_name, last_name
+        event_properties current_source
+      )
+    end
+
+    before do
+      Fluent::Test.setup
+      expect(AmplitudeAPI).to receive(:api_key=).with('XXXXXX')
+      response = double(:response, response_code: 200)
+      allow(AmplitudeAPI).to receive(:track).with(kind_of(Array)).and_return(
+        response
+      )
+      allow(response).to receive(:total_time).and_return(123)
+      allow_any_instance_of(Statsd).to receive(:track)
+    end
+
     before do
       amplitude.tag = tag
       amplitude.emit(event, now)
@@ -345,6 +345,24 @@ describe Fluent::AmplitudeOutput do
         amplitude.expect_format [tag, now, formatted_event].to_msgpack
         amplitude.run
       end
+    end
+  end
+
+  describe 'log_error' do
+    it 'logs an error to the console' do
+      plugin = Fluent::AmplitudeOutput.new
+      message = 'Response: 429, Body: This is the body, Duration: 2000'
+
+      expect_any_instance_of(Statsd).to receive(:track).with(
+        'fluentd.amplitude.records_errored', 3
+      )
+      expect(plugin.log).to receive(:error).with(message)
+      plugin.send(:log_error,
+        code: 429,
+        body: 'This is the body',
+        records: ['foo', 'bar', 'baz'],
+        duration: 2000
+      )
     end
   end
 end


### PR DESCRIPTION
Let's just make each chunk small enough (via the config) that it won't trip any errors on Amplitude's side.

@robdiciuccio @change/data-science @change/platform 