### PR TITLE
Support Amplitude insert_id property

### DIFF
--- a/fluent-plugin-amplitude.gemspec
+++ b/fluent-plugin-amplitude.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'fluent-plugin-amplitude'
-  spec.version       = '1.0.0'
+  spec.version       = '1.1.0'
   spec.authors       = ['Change.org']
   spec.email         = ['tech_ops@change.org']
   spec.summary       = 'Fluentd plugin to output event data to Amplitude'

--- a/lib/fluent/plugin/out_amplitude.rb
+++ b/lib/fluent/plugin/out_amplitude.rb
@@ -108,12 +108,11 @@ module Fluent
     end
 
     def extract_insert_id!(amplitude_hash, record)
-      if @insert_id_key
-        @insert_id_key.each do |insert_id_key|
-          if record[insert_id_key]
-            amplitude_hash[:insert_id] = record.delete(insert_id_key)
-            break
-          end
+      return unless @insert_id_key
+      @insert_id_key.each do |insert_id_key|
+        if record[insert_id_key]
+          amplitude_hash[:insert_id] = record.delete(insert_id_key)
+          break
         end
       end
     end

--- a/lib/fluent/plugin/out_amplitude.rb
+++ b/lib/fluent/plugin/out_amplitude.rb
@@ -18,6 +18,7 @@ module Fluent
     config_param :api_key, :string, secret: true
     config_param :device_id_key, :array, default: nil
     config_param :user_id_key, :array, default: nil
+    config_param :insert_id_key, :array, default: nil
     config_param :time_key, :array, default: nil
     config_param :user_properties, :array, default: nil
     config_param :event_properties, :array, default: nil
@@ -53,6 +54,7 @@ module Fluent
 
       filter_properties_blacklist!(record)
       extract_user_and_device!(amplitude_hash, record)
+      extract_insert_id!(amplitude_hash, record)
       set_time!(amplitude_hash, record)
       extract_revenue_properties!(amplitude_hash, record)
       extract_user_properties!(amplitude_hash, record)
@@ -99,6 +101,17 @@ module Fluent
         @device_id_key.each do |device_id_key|
           if record[device_id_key]
             amplitude_hash[:device_id] = record.delete(device_id_key)
+            break
+          end
+        end
+      end
+    end
+
+    def extract_insert_id!(amplitude_hash, record)
+      if @insert_id_key
+        @insert_id_key.each do |insert_id_key|
+          if record[insert_id_key]
+            amplitude_hash[:insert_id] = record.delete(insert_id_key)
             break
           end
         end

--- a/spec/out_amplitude_spec.rb
+++ b/spec/out_amplitude_spec.rb
@@ -14,6 +14,7 @@ describe Fluent::AmplitudeOutput do
       api_key XXXXXX
       user_id_key user_id
       device_id_key uuid
+      insert_id_key event_uuid
       user_properties first_name, last_name
       event_properties current_source
     )
@@ -330,6 +331,55 @@ describe Fluent::AmplitudeOutput do
           event_type: tag,
           user_id: 42,
           device_id: 'e6153b00-85d8-11e6-b1bc-43192d1e493f',
+          time: Time.parse('2016-12-20T00:00:06Z').to_i,
+          user_properties: {
+            first_name: 'Bobby',
+            last_name: 'Weir'
+          },
+          event_properties: {
+            current_source: 'fb_share'
+          }
+        }
+      end
+
+      it 'produces the expected output' do
+        amplitude.expect_format [tag, now, formatted_event].to_msgpack
+        amplitude.run
+      end
+    end
+
+    context 'insert_id_key specified' do
+      let(:conf) do
+        %(
+          api_key XXXXXX
+          user_id_key user_id
+          device_id_key uuid
+          time_key created_at
+          insert_id_key event_uuid
+          user_properties first_name, last_name
+          event_properties current_source
+        )
+      end
+      let(:event) do
+        {
+          'user_id' => 42,
+          'uuid' => 'e6153b00-85d8-11e6-b1bc-43192d1e493f',
+          'first_name' => 'Bobby',
+          'last_name' => 'Weir',
+          'state' => 'CA',
+          'current_source' => 'fb_share',
+          'recruiter_id' => 710,
+          'created_at' => '2016-12-20T00:00:06Z',
+          'event_uuid' => '330e62a4-1e3b-48fc-975f-07771ea6f474',
+        }
+      end
+
+      let(:formatted_event) do
+        {
+          event_type: tag,
+          user_id: 42,
+          device_id: 'e6153b00-85d8-11e6-b1bc-43192d1e493f',
+          insert_id: '330e62a4-1e3b-48fc-975f-07771ea6f474',
           time: Time.parse('2016-12-20T00:00:06Z').to_i,
           user_properties: {
             first_name: 'Bobby',


### PR DESCRIPTION
Adds support for the [`insert_id`](https://amplitude.zendesk.com/hc/en-us/articles/204771828#optional-amplitude-specific-keys-for-the-event-argument) property, used to deduplicate events sent to Amplitude. This property is already supported by the [AmplitudeAPI](https://github.com/toothrot/amplitude-api/blob/master/lib/amplitude_api/event.rb#L67) module.