### PR TITLE
add a 2000 event limit to amplitude event batch

### DIFF
--- a/lib/fluent/plugin/out_amplitude.rb
+++ b/lib/fluent/plugin/out_amplitude.rb
@@ -71,6 +71,9 @@ module Fluent
         record = simple_symbolize_keys(record)
         if verify_user_and_device(record)
           records << AmplitudeAPI::Event.new(record)
+          if records.length >= 2000
+            send_to_amplitude(records)
+            records = []
         else
           log.info(
             "Error: either user_id or device_id must be set for tag #{tag}"


### PR DESCRIPTION
2000 event limit on amplitude batches because we're sending more at a time with our current setup.


@willbarrett @joycechangeorg 