### PR TITLE
Reject all-0 UUIDs in the Amplitude out plugin

### DIFF
--- a/fluent-plugin-amplitude.gemspec
+++ b/fluent-plugin-amplitude.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'fluent-plugin-amplitude'
-  spec.version       = '1.1.0'
+  spec.version       = '1.1.1'
   spec.authors       = ['Change.org']
   spec.email         = ['tech_ops@change.org']
   spec.summary       = 'Fluentd plugin to output event data to Amplitude'

--- a/lib/fluent/plugin/out_amplitude.rb
+++ b/lib/fluent/plugin/out_amplitude.rb
@@ -120,7 +120,7 @@ module Fluent
     def verify_user_and_device(amplitude_hash)
       user_id = amplitude_hash[:user_id]
       device_id = amplitude_hash[:device_id]
-      present?(user_id) || present?(device_id)
+      present?(user_id) || (present?(device_id) && device_id != '00000000-0000-0000-0000-000000000000')
     end
 
     def set_time!(amplitude_hash, record)
@@ -177,6 +177,7 @@ module Fluent
 
     def send_to_amplitude(records)
       log.info("sending #{records.length} to amplitude")
+
       res = AmplitudeAPI.track(records)
       @statsd.timing('fluentd.amplitude.request_time', res.total_time * 1000)
       if res.response_code == 200

--- a/spec/out_amplitude_spec.rb
+++ b/spec/out_amplitude_spec.rb
@@ -174,6 +174,24 @@ describe Fluent::AmplitudeOutput do
       end
     end
 
+    context 'the input contains an all-0 device_id field and an empty user_id' do
+      let(:event) do
+        {
+          'user_id' => '',
+          'uuid' => '00000000-0000-0000-0000-000000000000',
+          'first_name' => 'Bobby',
+          'last_name' => 'Weir',
+          'state' => 'CA',
+          'current_source' => 'fb_share',
+          'recruiter_id' => 710
+        }
+      end
+      it 'does not track the event' do
+        expect(AmplitudeAPI).to_not receive(:track)
+        amplitude.run
+      end
+    end
+
     context 'properties_blacklist is specified' do
       let(:conf) do
         %(


### PR DESCRIPTION
@robdiciuccio @erikogan @change/data-science 

Reject a particularly problematic UUID that was emitted as part of a backfill