### PR TITLE
Fix the statsd setup, add error code monitoring

### DIFF
--- a/fluent-plugin-amplitude.gemspec
+++ b/fluent-plugin-amplitude.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'fluent-plugin-amplitude'
-  spec.version       = '1.1.1'
+  spec.version       = '1.2.0'
   spec.authors       = ['Change.org']
   spec.email         = ['tech_ops@change.org']
   spec.summary       = 'Fluentd plugin to output event data to Amplitude'

--- a/lib/fluent/plugin/out_amplitude.rb
+++ b/lib/fluent/plugin/out_amplitude.rb
@@ -180,8 +180,9 @@ module Fluent
 
       res = AmplitudeAPI.track(records)
       @statsd.timing('fluentd.amplitude.request_time', res.total_time * 1000)
+      @statsd.increment("fluentd.amplitude.response_code.#{res.response_code}")
       if res.response_code == 200
-        @statsd.increment(
+        @statsd.count(
           'fluentd.amplitude.records_sent',
           records.length
         )
@@ -201,7 +202,7 @@ module Fluent
     end
 
     def log_error(error)
-      @statsd.increment(
+      @statsd.count(
         'fluentd.amplitude.records_errored',
         error[:records].length
       )


### PR DESCRIPTION
The previous implementation of the statsd integration called `increment` with a second argument representing the count to increment by. This does not match the method signature of `increment`. The second argument to this function is the sampling rate to apply to the metric. As a result, all of our metrics from this plugin are off by several orders of magnitude.

This PR also adds tracking of API response codes, which uses the `increment` method correctly.

@change/data-science 